### PR TITLE
Potential fix for code scanning alert no. 116: Assignment to constant

### DIFF
--- a/GALAX_App_files/client/src/pages/RegisterPage.tsx
+++ b/GALAX_App_files/client/src/pages/RegisterPage.tsx
@@ -29,11 +29,9 @@ export function RegisterPage() {
     setIsLoading(true);
 
     try {
-      const identifier = signupMethod === 'email' ? email : phone;
-      await register(identifier, password, username, signupMethod);
       // Format phone number with country code if it's a phone signup
       const identifier = signupMethod === 'email' ? email : `${countryCode}${phone.replace(/^[\+\s0]+/, '')}`;
-      await register(identifier, password, username);
+      await register(identifier, password, username, signupMethod);
       navigate('/dashboard');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Registration failed');


### PR DESCRIPTION
Potential fix for [https://github.com/rsl37/GALAX_Civic_Networking_App/security/code-scanning/116](https://github.com/rsl37/GALAX_Civic_Networking_App/security/code-scanning/116)

To fix the problem, we need to avoid redeclaring the `identifier` constant within the same scope. The best approach is to define `identifier` only once, after all necessary information is available. In this case, the code first calls `register` with an `identifier` that is either the email or phone, and then, if the signup method is phone, it formats the phone number with the country code and calls `register` again. This seems redundant and possibly a logic error.

However, to preserve existing functionality, we should clarify the intended logic. If the intent is to call `register` only once, with the properly formatted identifier, then we should move the logic for formatting the identifier before the first call. If two calls are intended (which seems unlikely), we should use different variable names.

Assuming the correct logic is to call `register` only once, with the properly formatted identifier, we should remove the first declaration and use only the second, which handles both cases correctly.

**Changes to make:**
- Remove the first `const identifier = ...` on line 32.
- Use the second `const identifier = ...` on line 35, but move it before the first call to `register`.
- Remove the redundant call to `register` (either line 33 or 36, depending on which is correct).
- Ensure that only one `const identifier` is declared and used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
